### PR TITLE
Array data should be output as JSON object

### DIFF
--- a/lib/autoresponse-processor.js
+++ b/lib/autoresponse-processor.js
@@ -112,7 +112,7 @@ function getJSONPRespnoseData(data, context) {
  * @return {{type: string, data: string, timeout: number}}
  */
 function getResponseData(data, resType, context) {
-    var isObj =  (data && _.isPlainObject(data));
+    var isObj =  (data && (_.isPlainObject(data) || _.isArray(data)));
 
     // 如果有设置超时选项，暂时移除该选项，该选项不做为响应数据一部分
     var timeout;


### PR DESCRIPTION
当mock数据为如下格式时：

``` js
// mock.js
module.exports = [{
  abc: 123,
  def: 'xxxx'
}];
```

由于不是 plainObject ，所以输出格式显示为：

```
[ [object,object] ]
```

期待的则是一个标准的 JSON 输出格式。
