### PR TITLE
【bug】fix rewrite url followed by null bug

### DIFF
--- a/lib/autoresponse-util.js
+++ b/lib/autoresponse-util.js
@@ -24,7 +24,7 @@ exports.isRequestJSFile = function (context) {
  */
 exports.rewriteRequestURL = function (context, forwardPath) {
     if (forwardPath) {
-        context.req.url = forwardPath + context.url.search;
+        context.req.url = forwardPath + (context.url.search || '');
     }
 };
 


### PR DESCRIPTION
In the case of /account/getUserInfo proxy to /mock/getUserInfo example , the context.req.url rewrited to /mock/getUserInfonull , lead to 404